### PR TITLE
INIT_PLAYER_AND_OPPONENT in a single event and added robustness when UPDATE_TURN gets received before INIT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,12 +90,6 @@
             <version>2.35.1</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>28.2-jre</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,12 @@
             <version>2.35.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>28.2-jre</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/matag/game/init/InitController.java
+++ b/src/main/java/com/matag/game/init/InitController.java
@@ -1,6 +1,5 @@
 package com.matag.game.init;
 
-import com.google.common.collect.ImmutableMap;
 import com.matag.adminentities.DeckInfo;
 import com.matag.adminentities.PlayerInfo;
 import com.matag.game.cardinstance.CardInstance;
@@ -122,7 +121,7 @@ public class InitController {
   }
 
   private static Map<String, InitPlayerEvent> initPlayerAndOpponentEvent(Player player, Player opponent) {
-    return ImmutableMap.of(
+    return Map.of(
             "player", InitPlayerEvent.createForPlayer(player),
             "opponent", InitPlayerEvent.createForOpponent(opponent));
   }

--- a/src/main/js/game/PlayerInfo/PlayerUtils.js
+++ b/src/main/js/game/PlayerInfo/PlayerUtils.js
@@ -12,7 +12,7 @@ export default class PlayerUtils {
   }
 
   static isCurrentPlayerActive(state) {
-    return state.player && state.turn && state.turn.currentPhaseActivePlayer === state.player.name
+    return get(state, 'player.name') === get(state, 'turn.currentPhaseActivePlayer')
   }
 
   static getPlayerByName(state, playerName) {

--- a/src/main/js/game/PlayerInfo/PlayerUtils.js
+++ b/src/main/js/game/PlayerInfo/PlayerUtils.js
@@ -12,7 +12,7 @@ export default class PlayerUtils {
   }
 
   static isCurrentPlayerActive(state) {
-    return state.turn.currentPhaseActivePlayer === state.player.name
+    return state.player && state.turn && state.turn.currentPhaseActivePlayer === state.player.name
   }
 
   static getPlayerByName(state, playerName) {

--- a/src/main/js/game/_reducers/ServerEventsReducer.js
+++ b/src/main/js/game/_reducers/ServerEventsReducer.js
@@ -4,7 +4,7 @@ import UserInterfaceUtils from 'game/UserInterface/UserInterfaceUtils'
 
 export default class ServerEventsReducer {
   static getEvents() {
-    return ['MESSAGE', 'INIT_WAITING_OPPONENT', 'OPPONENT_JOINED', 'INIT_PLAYER', 'INIT_OPPONENT', 'UPDATE_TURN', 'UPDATE_STACK',
+    return ['MESSAGE', 'INIT_WAITING_OPPONENT', 'OPPONENT_JOINED', 'INIT_PLAYER_AND_OPPONENT', 'UPDATE_TURN', 'UPDATE_STACK',
       'UPDATE_PLAYER_BATTLEFIELD', 'UPDATE_PLAYER_HAND', 'UPDATE_PLAYER_GRAVEYARD', 'UPDATE_PLAYER_LIFE', 'UPDATE_PLAYER_LIBRARY_SIZE']
   }
 
@@ -23,12 +23,9 @@ export default class ServerEventsReducer {
       UserInterfaceUtils.unsetMessage(newState)
       break
 
-    case 'INIT_PLAYER':
-      newState.player = action.value
-      break
-
-    case 'INIT_OPPONENT':
-      newState.opponent = action.value
+    case 'INIT_PLAYER_AND_OPPONENT':
+      newState.player = action.value.player
+      newState.opponent = action.value.opponent
       break
 
     case 'UPDATE_TURN':


### PR DESCRIPTION
Sending INIT_PLAYER and INIT_OPPONENT in a single event.
Safer player utils which doesn't break if clients receives an UPDATE_TURN before INIT_PLAYER_AND_OPPONENT.